### PR TITLE
fix: remove duplicate path setting for startupProbe in StatefulSet

### DIFF
--- a/memphis/templates/memphis_statefulset.yaml
+++ b/memphis/templates/memphis_statefulset.yaml
@@ -580,7 +580,6 @@ spec:
             # During upgrades, healthz will be enabled instead to allow for a grace period
             # in case of JetStream enabled deployments to form quorum and streams to catch up.
             path: /healthz
-            path: /
             port: 8222
         {{- with .Values.nats.healthcheck.startup }}
           initialDelaySeconds: {{ .initialDelaySeconds }}

--- a/memphis/templates/memphis_statefulset.yaml
+++ b/memphis/templates/memphis_statefulset.yaml
@@ -579,7 +579,7 @@ spec:
           httpGet:
             # During upgrades, healthz will be enabled instead to allow for a grace period
             # in case of JetStream enabled deployments to form quorum and streams to catch up.
-            path: /healthz
+            path: /
             port: 8222
         {{- with .Values.nats.healthcheck.startup }}
           initialDelaySeconds: {{ .initialDelaySeconds }}


### PR DESCRIPTION
Duplicate `path` value for startupProbe prevented helm installation