### PR TITLE
Improvement/request limit cpu configurable

### DIFF
--- a/memphis/templates/memphis-rest-gateway.yaml
+++ b/memphis/templates/memphis-rest-gateway.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
         - name: k8s-busybox-waits4broker

--- a/memphis/templates/memphis-rest-gateway.yaml
+++ b/memphis/templates/memphis-rest-gateway.yaml
@@ -47,12 +47,10 @@ spec:
         - name: memphis-rest-gateway
           image: {{ .Values.restGateway.image }}
           resources:
-            limits:
-              cpu: 500m
-              memory: 500Mi
-          imagePullPolicy: Always
+            {{- .Values.restGateway.resources | toYaml | noindent 4 }}
+          imagePullPolicy: {{ .Values.restGaway.pullPolicy }}
           ports:
-            - containerPort: 4444
+            - containerPort: {{ .Values.restGateway.port }}
           env:
           - name: ROOT_USER
             value: {{ .Values.restGateway.user | quote }}

--- a/memphis/templates/memphis-rest-gateway.yaml
+++ b/memphis/templates/memphis-rest-gateway.yaml
@@ -50,7 +50,7 @@ spec:
             {{- .Values.restGateway.resources | toYaml | noindent 4 }}
           imagePullPolicy: {{ .Values.restGaway.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.restGateway.port }}
+            - containerPort: 4444
           env:
           - name: ROOT_USER
             value: {{ .Values.restGateway.user | quote }}

--- a/memphis/templates/memphis-rest-gateway.yaml
+++ b/memphis/templates/memphis-rest-gateway.yaml
@@ -38,6 +38,10 @@ spec:
       labels:
         app: memphis-rest-gateway
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
       initContainers:
         - name: k8s-busybox-waits4broker
           image: busybox:1.28

--- a/memphis/templates/memphis-rest-gateway.yaml
+++ b/memphis/templates/memphis-rest-gateway.yaml
@@ -47,8 +47,8 @@ spec:
         - name: memphis-rest-gateway
           image: {{ .Values.restGateway.image }}
           resources:
-            {{- .Values.restGateway.resources | toYaml | noindent 4 }}
-          imagePullPolicy: {{ .Values.restGaway.pullPolicy }}
+            {{- toYaml .Values.restGateway.resources | nindent 12 }}
+          imagePullPolicy: {{ .Values.restGateway.pullPolicy }}
           ports:
             - containerPort: 4444
           env:

--- a/memphis/values.yaml
+++ b/memphis/values.yaml
@@ -466,6 +466,12 @@ restGateway:
   port: 4444
   image: memphisos/memphis-rest-gateway:master
   pullPolicy: Always
+  resources:
+    limits:
+      memory: 500Mi
+    requests:
+      cpu: 500m
+      memory: 500Mi
 
 # Authentication setup
 auth:


### PR DESCRIPTION
Depending on the environment this is running we dont really need to
request half of a cpu. Make this configurable to be more flexible.

Furthermore I moved the default resources to ask for cpu request instead of
limit. Limiting the pod in cpu is a bit of an anti pattern on kubernetes. See [this blog](https://home.robusta.dev/blog/stop-using-cpu-limits) for more information.