### PR TITLE
Improvement/make busybox configurable

### DIFF
--- a/memphis/templates/memphis-rest-gateway.yaml
+++ b/memphis/templates/memphis-rest-gateway.yaml
@@ -38,10 +38,14 @@ spec:
       labels:
         app: memphis-rest-gateway
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: k8s-busybox-waits4broker
-          image: busybox:1.28
-          imagePullPolicy: Always
+          image: {{ .Values.busybox.image }}
+          imagePullPolicy: {{ .Values.busybox.pullPolicy }}
           command: ['sh', '-c', "until nslookup {{ include "memphis.svcName" . }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for broker; sleep 2; done"]
       containers:
         - name: memphis-rest-gateway

--- a/memphis/templates/memphis_statefulset.yaml
+++ b/memphis/templates/memphis_statefulset.yaml
@@ -251,16 +251,16 @@ spec:
       {{- if .Values.metadata.enabled }}
       {{- if .Values.global.cluster.enabled }}
         - name: memphis-metadata-readiness
-          image: busybox:1.36.0
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.busybox.image }}
+          imagePullPolicy: {{ .Values.busybox.pullPolicy }}
           env:
           - name: NAMESPACE
             value: {{ include "memphis.namespace" . }}
           command: ['sh', '-c', "until nslookup {{ .Values.metadata.fullnameOverride }}-1.{{ .Values.metadata.fullnameOverride }}-headless.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for memphis-metadata; sleep 2; done"]
       {{- else }}
         - name: memphis-metadata-readiness
-          image: busybox:1.36.0
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.busybox.image }}
+          imagePullPolicy: {{ .Values.busybox.pullPolicy }}
           env:
           - name: NAMESPACE
             value: {{ include "memphis.namespace" . }}

--- a/memphis/values.yaml
+++ b/memphis/values.yaml
@@ -458,6 +458,10 @@ exporter:
     # interval:
     # scrapeTimeout:
 
+# Memphis busybox configuration
+busybox:
+  image: busybox:1.36.0
+  pullPolicy: IfNotPresent
 
 # Memphis REST Gateway configuration
 restGateway:

--- a/memphis/values.yaml
+++ b/memphis/values.yaml
@@ -460,7 +460,7 @@ exporter:
 
 # Memphis busybox configuration
 busybox:
-  image: busybox:1.36.0
+  image: busybox:1.36.1
   pullPolicy: IfNotPresent
 
 # Memphis REST Gateway configuration


### PR DESCRIPTION
# ⚠ Potential breaking change ⚠

The version of busybox for container k8s-busybox-waits4broker has been bumped from 1.28 to 1.36.1.
Container started successfully and waited for the broker to be up. Still you might want to have a look at the [release notes](https://busybox.net/) in case I missed something that breaks the deployment.
