### PR TITLE
feat: add appProtocol to service

### DIFF
--- a/memphis/templates/memphis_service.yaml
+++ b/memphis/templates/memphis_service.yaml
@@ -24,11 +24,15 @@ spec:
   - name: memphis-cp-management
     port: 9000
     targetPort: 9000
+    appProtocol: http
   - name: memphis-ws
     port: 7770
     targetPort: 7770
+    appProtocol: tcp
   - name: memphis-cp-tcp
     port: 6666
     targetPort: 6666
+    appProtocol: tcp
   - name: monitor
     port: 8222
+    appProtocol: http


### PR DESCRIPTION
Add `appProtocol` entry to ports in service resource to support automatic protocol detection for most common service meshes like [istio](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/) or [kong](https://docs.konghq.com/mesh/latest/policies/protocol-support-in-kong-mesh/). This will help to integrate Memphis well with these services meshes and allow better communication between backend services.