### PR TITLE
use targetPort in ServiceMonitor resource

### DIFF
--- a/memphis/templates/memphis_serviceMonitor.yaml
+++ b/memphis/templates/memphis_serviceMonitor.yaml
@@ -18,7 +18,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - port: {{ .Values.exporter.portName }}
+  - targetPort: {{ .Values.exporter.portName }}
   {{- if .Values.exporter.serviceMonitor.path }}
     path: {{ .Values.exporter.serviceMonitor.path }}
   {{- end }}


### PR DESCRIPTION
use targetPort to reference the port of the pod instead of the port of the service.

Fixes #191.