### PR TITLE
fix: typo in the apiVersion

### DIFF
--- a/memphis/templates/memphis-rest-gateway.yaml
+++ b/memphis/templates/memphis-rest-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: /v1
+apiVersion: v1
 kind: Service
 metadata:
   name: memphis-rest-gateway


### PR DESCRIPTION
Spotted when deploying with ArgoCD, the version for the service should be `v1` (https://kubernetes.io/docs/concepts/services-networking/service/)

<img width="905" alt="Screenshot 2023-12-06 at 11 25 47" src="https://github.com/memphisdev/memphis-k8s/assets/32224751/e8f4b251-6518-45f4-80f7-866a9c590717">
